### PR TITLE
Update string escapes

### DIFF
--- a/syntaxes/roc.tmLanguage.json
+++ b/syntaxes/roc.tmLanguage.json
@@ -8,7 +8,7 @@
       "name": "keyword.unused.roc"
     },
     {
-      "match": "\\b(dbg|if|then|else|when|is|app|packages|imports|provides|to|as|expect|exposes)\\s+",
+      "match": "\\b(dbg|if|then|else|when|is|app|packages|imports?|provides|to|as|expect|exposes)\\s+",
       "name": "keyword.control.roc"
     },
     { "include": "#comments" },

--- a/syntaxes/roc.tmLanguage.json
+++ b/syntaxes/roc.tmLanguage.json
@@ -118,12 +118,58 @@
           },
           "patterns": [
             {
-              "match": "\\\\(NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE|DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS|US|SP|DEL|[abfnrtv\\\\\\\"'\\&]|x[0-9a-fA-F]{1,5})",
+              "name": "invalid.illegal",
+              "begin": "\\\\u\\(",
+              "beginCaptures": {
+                "0": {
+                  "name": "constant.character.escape.roc"
+                }
+              },
+              "end": "\\)",
+              "endCaptures": {
+                "0": {
+                  "name": "constant.character.escape.roc"
+                }
+              },
+              "patterns": [
+                {
+                  "match": "[0-9a-fA-F]+",
+                  "name": "constant.numeric.roc"
+                }
+              ]
+            },
+            {
+              "match": "\\\\[nrt\\\\\\\"\\\\]",
               "name": "constant.character.escape.roc"
             },
             {
-              "match": "\\^[A-Z@\\[\\]\\\\\\^_]",
-              "name": "constant.character.escape.control.roc"
+              "name": "source.roc",
+              "begin": "\\$\\(",
+              "beginCaptures": {
+                "0": {
+                  "name": "constant.character.escape.roc"
+                }
+              },
+              "end": "\\)",
+              "endCaptures": {
+                "0": {
+                  "name": "constant.character.escape.roc"
+                }
+              },
+              "patterns": [
+                {
+                  "match": "\\b(dbg|expect|if|then|else|when|is|as)\\s+",
+                  "name": "keyword.control.roc"
+                },
+                { "include": "#comments" },
+                { "include": "#strings" },
+                { "include": "#numbers" },
+                { "include": "#punctuation" },
+                { "include": "#module-member-access" },
+                { "include": "#language-components" },
+                { "include": "#infix_op" },
+                { "include": "#type-signature" }
+              ]
             }
           ]
         },
@@ -143,12 +189,8 @@
           },
           "patterns": [
             {
-              "match": "\\\\(NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE|DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS|US|SP|DEL|[abfnrtv\\\\\\\"'\\&]|x[0-9a-fA-F]{1,5})",
+              "match": "\\\\[nrt\\\\'\\\\]",
               "name": "constant.character.escape.roc"
-            },
-            {
-              "match": "\\^[A-Z@\\[\\]\\\\\\^_]",
-              "name": "constant.character.escape.control.roc"
             }
           ]
         }


### PR DESCRIPTION
## Description

Add syntax highlighting for upcoming `import` and `$(...)` string interpolation syntax. The string interpolation highlighting also highlights everything inside the parens as normal Roc expressions!

Also cleans up some string escapes that aren't actually supported in Roc. 😄 

## Checklist

- [x] The commits use the [Conventional Commits format](https://www.conventionalcommits.org/en/v1.0.0/)
