### PR TITLE
Update header keywords to latest syntax

### DIFF
--- a/syntaxes/roc.tmLanguage.json
+++ b/syntaxes/roc.tmLanguage.json
@@ -8,7 +8,7 @@
       "name": "keyword.unused.roc"
     },
     {
-      "match": "\\b(dbg|if|then|else|when|is|app|packages|imports?|provides|to|as|expect|exposes)\\s+",
+      "match": "\\b(dbg|if|then|else|when|is|app|module|package|import|as|exposing|expect)\\s+",
       "name": "keyword.control.roc"
     },
     { "include": "#comments" },


### PR DESCRIPTION
## Description

Since the syntax highlighting was last updated:
- `imports` is now `import`
- `packages` has been removed
- `provides` and `to` have been removed
- `exposes` is now `exposing`

## Checklist

- [x] The commits use the [Conventional Commits format](https://www.conventionalcommits.org/en/v1.0.0/)
