### PR TITLE
chore: move ts-results to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "semantic-release": "^24.0.0",
     "semantic-release-vsce": "^5.7.2",
     "ts-loader": "^9.5.0",
-    "ts-results": "^3.3.0",
     "typescript": "^5.5.3",
     "webpack": "^5.92.1",
     "webpack-cli": "^5.1.4"
@@ -108,6 +107,7 @@
     ]
   },
   "dependencies": {
+    "ts-results": "^3.3.0",
     "vscode-languageclient": "^9.0.1"
   },
   "packageManager": "pnpm@8.14.1+sha256.2df78e65d433d7693b9d3fbdaf431b2d96bb4f96a2ffecd51a50efe16e50a6a8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  ts-results:
+    specifier: ^3.3.0
+    version: 3.3.0
   vscode-languageclient:
     specifier: ^9.0.1
     version: 9.0.1
@@ -58,9 +61,6 @@ devDependencies:
   ts-loader:
     specifier: ^9.5.0
     version: 9.5.1(typescript@5.5.3)(webpack@5.92.1)
-  ts-results:
-    specifier: ^3.3.0
-    version: 3.3.0
   typescript:
     specifier: ^5.5.3
     version: 5.5.3
@@ -4729,7 +4729,7 @@ packages:
 
   /ts-results@3.3.0:
     resolution: {integrity: sha512-FWqxGX2NHp5oCyaMd96o2y2uMQmSu8Dey6kvyuFdRJ2AzfmWo3kWa4UsPlCGlfQ/qu03m09ZZtppMoY8EMHuiA==}
-    dev: true
+    dev: false
 
   /tslib@2.6.3:
     resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}


### PR DESCRIPTION

## Description

The `ts-results` package is used in the source code, so it should not be a dev dependency

## Checklist

- [ ] The commits use the [Conventional Commits format](https://www.conventionalcommits.org/en/v1.0.0/)
