### PR TITLE
Fix husky warning

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 pnpm exec lint-staged


### PR DESCRIPTION
## Description

`husky` currently gives a warning to remove these two lines

## Checklist

- [x] The commits use the [Conventional Commits format](https://www.conventionalcommits.org/en/v1.0.0/)
