### PR TITLE
chore: add vcs section to biome config

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -22,8 +22,7 @@
       "suspicious": {
         "noDoubleEquals": "warn"
       }
-    },
-    "ignore": ["**/out", "**/dist", "**/*.d.ts"]
+    }
   },
   "javascript": {
     "formatter": {
@@ -45,5 +44,11 @@
     "formatter": {
       "trailingCommas": "none"
     }
+  },
+  "vcs": {
+    "clientKind": "git",
+    "defaultBranch": "main",
+    "enabled": true,
+    "useIgnoreFile": true
   }
 }


### PR DESCRIPTION
## Description

Adding a VCS section to the biome config lets us remove the ignore section.

## Checklist

- [x] The commits use the [Conventional Commits format](https://www.conventionalcommits.org/en/v1.0.0/)
