### PR TITLE
Update string interpolation syntax

### DIFF
--- a/syntaxes/roc.tmLanguage.json
+++ b/syntaxes/roc.tmLanguage.json
@@ -144,13 +144,13 @@
             },
             {
               "name": "source.roc",
-              "begin": "\\$\\(",
+              "begin": "\\$\\{",
               "beginCaptures": {
                 "0": {
                   "name": "constant.character.escape.roc"
                 }
               },
-              "end": "\\)",
+              "end": "\\}",
               "endCaptures": {
                 "0": {
                   "name": "constant.character.escape.roc"


### PR DESCRIPTION
## Description

String interpolation now uses `${` and `}` instead of `$(` and `)`

## Checklist

- [x] The commits use the [Conventional Commits format](https://www.conventionalcommits.org/en/v1.0.0/)
