### PR TITLE
Replace && with and and || with or

### DIFF
--- a/syntaxes/roc.tmLanguage.json
+++ b/syntaxes/roc.tmLanguage.json
@@ -8,7 +8,7 @@
       "name": "keyword.unused.roc"
     },
     {
-      "match": "\\b(dbg|if|then|else|when|is|app|packages|imports?|provides|to|as|expect|exposes)\\s+",
+      "match": "\\b(dbg|if|then|else|when|is|app|packages|imports?|provides|to|as|expect|exposes|and|or)\\s+",
       "name": "keyword.control.roc"
     },
     { "include": "#comments" },
@@ -69,7 +69,7 @@
       "name": "keyword.other.period.roc"
     },
     "infix_op": {
-      "match": "(</>|<\\?>|<\\||<=|\\|\\||&&|>=|\\|>|\\|=|\\|\\.|\\+\\+|::|/=|==|//|>>|<<|<|>|\\^|\\+|-|/|\\*)",
+      "match": "(</>|<\\?>|<\\||<=|>=|\\|>|\\|=|\\|\\.|\\+\\+|::|/=|==|//|>>|<<|<|>|\\^|\\+|-|/|\\*)",
       "name": "keyword.operator.roc"
     },
     "unit": {


### PR DESCRIPTION
## Description

Roc now uses `and` and `or` for boolean operators instead of `&&` and `||` operators 

## Checklist

- [x] The commits use the [Conventional Commits format](https://www.conventionalcommits.org/en/v1.0.0/)
