### PR TITLE
Update roc in nix flake to v0.0.0-alpha2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,10 +34,34 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixgl": {
       "inputs": {
-        "flake-utils": ["roc", "flake-utils"],
-        "nixpkgs": ["roc", "nixpkgs"]
+        "flake-utils": [
+          "roc",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "roc",
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1710868679,
@@ -71,17 +95,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1712163089,
-        "narHash": "sha256-Um+8kTIrC19vD4/lUCN9/cU9kcOsD1O1m+axJqQPyMM=",
+        "lastModified": 1722403750,
+        "narHash": "sha256-tRmn6UiFAPX0m9G1AVcEPjWEOc9BtGsxGcs7Bz3MpsM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fd281bd6b7d3e32ddfa399853946f782553163b5",
+        "rev": "184957277e885c06a505db112b35dfbec7c60494",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fd281bd6b7d3e32ddfa399853946f782553163b5",
+        "rev": "184957277e885c06a505db112b35dfbec7c60494",
         "type": "github"
       }
     },
@@ -94,15 +118,16 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1720462741,
-        "narHash": "sha256-ZPhjaStxRY/IMKtAbEi4DJOGUvWj3Sei5K18SE2+YjA=",
+        "lastModified": 1738131757,
+        "narHash": "sha256-cXWFnT2SlNvc8gRAhlUNakVGWii3VWZsvNijMRpX7XA=",
         "owner": "roc-lang",
         "repo": "roc",
-        "rev": "b9a17f4a49b743d5e76ce592ce5a64d93c9d6f4b",
+        "rev": "689c58f35e0a39ca59feba549f7fcf375562a7a6",
         "type": "github"
       },
       "original": {
         "owner": "roc-lang",
+        "ref": "0.0.0-alpha2-rolling",
         "repo": "roc",
         "type": "github"
       }
@@ -115,8 +140,11 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": ["roc", "flake-utils"],
-        "nixpkgs": ["roc", "nixpkgs"]
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "roc",
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1713150335,
@@ -133,6 +161,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     roc = {
-      url = "github:roc-lang/roc";
+      url = "github:roc-lang/roc/0.0.0-alpha2-rolling";
       # inputs.nixpkgs.follows = "nixpkgs";
     };
   };


### PR DESCRIPTION
## Description

Updates the version of Roc in the Nix flake to the latest alpha `v0.0.0-alpha2`

## Checklist

- [x] The commits use the [Conventional Commits format](https://www.conventionalcommits.org/en/v1.0.0/)
